### PR TITLE
Paged lists

### DIFF
--- a/zygrader/main.py
+++ b/zygrader/main.py
@@ -108,7 +108,8 @@ def view_changelog():
     lines = config.versioning.load_changelog()
 
     popup = ui.layers.ListLayer("Changelog", popup=True)
-    popup.set_exit_text("Close")
+    popup.set_exit_text("Press enter to close")
+    popup.set_paged()
     for line in lines:
         popup.add_row_text(line)
     window.run_layer(popup, "Changelog")

--- a/zygrader/ui/components.py
+++ b/zygrader/ui/components.py
@@ -701,11 +701,14 @@ class ScrollableList(Component):
         lines.sort(key=lambda line: line.sort_index)
         return lines
 
+    def __should_show_selected(self, number):
+        return number + self._scroll == self._selected_index and not self._paged
+
     def _draw_list_lines(self, window, lines, y_start, x_start):
         for line_number, line in enumerate(lines):
             prefix = ScrollableList.UNSELECTED_PREFIX
             attributes = 0
-            if line_number + self._scroll == self._selected_index and not self._paged:
+            if self.__should_show_selected(line_number):
                 prefix = ScrollableList.SELECTED_PREFIX
                 attributes = curses.A_BOLD
 

--- a/zygrader/ui/components.py
+++ b/zygrader/ui/components.py
@@ -696,6 +696,18 @@ class ScrollableList(Component):
         lines.sort(key=lambda line: line.sort_index)
         return lines
 
+    def _draw_list_lines(self, window, lines, y_start, x_start):
+        for line_number, line in enumerate(lines):
+            if line_number + self._scroll == self._selected_index:
+                add_str(window, y_start + line_number, x_start,
+                        f"{ScrollableList.SELECTED_PREFIX}{line.text}",
+                        curses.A_BOLD | line.color)
+            else:
+                add_str(window, y_start + line_number, x_start,
+                        f"{ScrollableList.UNSELECTED_PREFIX}{line.text}",
+                        curses.A_DIM | line.color)
+        window.noutrefresh()
+
     def __scroll_to_top(self):
         self._selected_index = 0
         self.set_scroll()
@@ -775,16 +787,7 @@ class FilteredList(ScrollableList):
         # TODO: Can we avoid slicing here?
         visible_lines = self._display_lines[self._scroll:self._scroll +
                                             self._rows - 1]
-        for line_number, line in enumerate(visible_lines):
-            if line_number + self._scroll == self._selected_index:
-                add_str(self.window, line_number, 0,
-                        f"{ScrollableList.SELECTED_PREFIX}{line.text}",
-                        curses.A_BOLD | line.color)
-            else:
-                add_str(self.window, line_number, 0,
-                        f"{ScrollableList.UNSELECTED_PREFIX}{line.text}",
-                        curses.A_DIM | line.color)
-        self.window.noutrefresh()
+        self._draw_list_lines(self.window, visible_lines, 0, 0)
 
         # Draw the optional search field
         if self._searchable:
@@ -833,16 +836,8 @@ class ListPopup(Popup, ScrollableList):
 
         visible_lines = self._display_lines[self._scroll:self._scroll +
                                             self.rows - ListPopup.V_PADDING]
-        for line_number, line in enumerate(visible_lines):
-            if line_number + self._scroll == self._selected_index:
-                add_str(self.window, Popup.PADDING + line_number, Popup.PADDING,
-                        f"{ScrollableList.SELECTED_PREFIX}{line.text}",
-                        curses.A_BOLD | line.color)
-            else:
-                add_str(self.window, Popup.PADDING + line_number, Popup.PADDING,
-                        f"{ScrollableList.UNSELECTED_PREFIX}{line.text}",
-                        curses.A_DIM | line.color)
-        self.window.noutrefresh()
+        self._draw_list_lines(self.window, visible_lines, Popup.PADDING,
+                              Popup.PADDING)
 
         if self._searchable:
             self.text_input.erase()

--- a/zygrader/ui/layers.py
+++ b/zygrader/ui/layers.py
@@ -529,6 +529,7 @@ class ListLayer(ComponentLayer, PopupLayer):
         ComponentLayer.__init__(self)
 
         self.__rows = Row(_type=Row.HOLDER)
+        self._paged = False
 
         if popup:
             win = window.Window.get_window()
@@ -579,7 +580,15 @@ class ListLayer(ComponentLayer, PopupLayer):
     def set_sortable(self):
         self.component.set_sortable()
 
+    def set_paged(self):
+        self.component.set_paged()
+        self._paged = True
+
     def event_handler(self, event: Event, event_manager: EventManager):
+        if self._paged and event.type == Event.ENTER:
+            event_manager.push_layer_close_event()
+            return
+
         if event.type == Event.DOWN:
             self.component.down()
         elif event.type == Event.UP:


### PR DESCRIPTION
This adds paging to list views. Paged list views are purely for showing text content, so there is no selected row, and pressing Enter closes the layer. Scrolling up and down moves all lines.

Also includes a cleanup on the layers code for drawing list lines.

Closes #31 