### PR TITLE
Default Output Directory

### DIFF
--- a/zygrader/admin.py
+++ b/zygrader/admin.py
@@ -1,6 +1,7 @@
 """Admin: Functions for more "administrator" users of zygrader to manage
 the class, scan through student submissions, and access to other menus"""
 import time
+from zygrader.config import preferences
 
 import requests
 import re
@@ -128,6 +129,7 @@ def submission_search_init():
     # Get a valid output path
     filename_input = ui.layers.PathInputLayer("Output File")
     filename_input.set_prompt(["Enter the filename to save the search results"])
+    filename_input.set_text(preferences.get("output_dir"))
     window.run_layer(filename_input, "Submissions Search")
     if filename_input.was_canceled():
         return

--- a/zygrader/config/preferences.py
+++ b/zygrader/config/preferences.py
@@ -35,7 +35,7 @@ DEFAULT_PREFERENCES = {
     "class_code": "No Override",
     "editor": "Pluma",
     "data_dir": "",
-    "output_dir": "~",
+    "output_dir": "~/",
 }
 
 CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".config/zygrader")

--- a/zygrader/config/preferences.py
+++ b/zygrader/config/preferences.py
@@ -35,6 +35,7 @@ DEFAULT_PREFERENCES = {
     "class_code": "No Override",
     "editor": "Pluma",
     "data_dir": "",
+    "output_dir": "~",
 }
 
 CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".config/zygrader")

--- a/zygrader/config/versioning.py
+++ b/zygrader/config/versioning.py
@@ -97,6 +97,9 @@ def versioning_update_preferences():
     if compare_versions(version, user_version):
         config["spooky_mode"] = False
 
+    # Code here will always be run until the next version bump
+    config["output_dir"] = "~"
+
 
 def find_versioning_message(window, version, user_version):
     """Display a versioning message for the given version number if one exists."""

--- a/zygrader/config/versioning.py
+++ b/zygrader/config/versioning.py
@@ -47,12 +47,22 @@ def update_user_version():
     preferences.set("version", SharedData.VERSION.vstring)
 
 
+def update_config_with_new_preferences(config: dict):
+    """Ensure new user preferences are stored in existing config files."""
+    for preference in preferences.DEFAULT_PREFERENCES:
+        if preference not in config:
+            preferences.set(preference,
+                            preferences.DEFAULT_PREFERENCES[preference])
+
+
 def versioning_update_preferences():
     """Compare the user's current version in the config and make necessary adjustments."""
 
     # To modify the config with more flexibility, we need access to the raw json.
     config = preferences.get_config()
     user_version = config["version"]
+
+    update_config_with_new_preferences(config)
 
     if isinstance(user_version, float):
         user_version = str(user_version)
@@ -96,9 +106,6 @@ def versioning_update_preferences():
     version = "4.9.0"
     if compare_versions(version, user_version):
         config["spooky_mode"] = False
-
-    # Code here will always be run until the next version bump
-    config["output_dir"] = "~"
 
 
 def find_versioning_message(window, version, user_version):

--- a/zygrader/grade_puller.py
+++ b/zygrader/grade_puller.py
@@ -1,5 +1,7 @@
 import csv
 import datetime
+import os
+from zygrader.config import preferences
 
 from zygrader import data, ui
 from zygrader.config.shared import SharedData
@@ -438,8 +440,12 @@ class GradePuller:
         return zybooks_students
 
     def write_upload_file(self):
-        default_path_str = "~/" + "&".join(self.selected_assignments) + ".csv"
-        default_path_str = default_path_str.replace(" ", "")
+        selected_assignments = "&".join(self.selected_assignments) + ".csv"
+        selected_assignments.replace(" ", "")
+
+        default_path_str = os.path.join(preferences.get("output_dir"),
+                                        selected_assignments)
+
         path = filename_input(purpose="the upload file", text=default_path_str)
         if path is None:
             raise GradePuller.StoppingException()
@@ -484,11 +490,10 @@ class GradePuller:
             num_id_columns = GradePuller.NUM_CANVAS_ID_COLUMNS
             canvas_report_headers = self.canvas_header[:num_id_columns]
             self.report_list(
-                unmatched_canvas_students,
-                canvas_report_headers,
+                unmatched_canvas_students, canvas_report_headers,
                 "unmatched canvas students",
-                "~/unmatched_canvas.csv",
-            )
+                os.path.join(preferences.get("output_dir"),
+                             "unmatched_canvas.csv"))
 
             num_id_columns = GradePuller.NUM_ZYBOOKS_ID_COLUMNS
             zybooks_report_headers = zybooks_header[:num_id_columns]
@@ -496,7 +501,8 @@ class GradePuller:
                 unmatched_zybook_students,
                 zybooks_report_headers,
                 "unmatched zybooks students",
-                "~/unmatched_zybooks.csv",
+                os.path.join(preferences.get("output_dir"),
+                             "unmatched_zybooks.csv"),
             )
 
         except GradePuller.StoppingException:

--- a/zygrader/main.py
+++ b/zygrader/main.py
@@ -214,6 +214,9 @@ def start():
     data.get_students()
     data.get_labs()
 
+    # Change directory to the default output dir
+    os.chdir(os.path.expanduser(preferences.get("output_dir")))
+
     # Create a zygrader window, callback to main function
     ui.Window(main, f"zygrader {SharedData.VERSION}", args)
 

--- a/zygrader/ui/layers.py
+++ b/zygrader/ui/layers.py
@@ -290,7 +290,7 @@ class PathInputLayer(TextInputLayer):
             directory, name = os.path.split(path)
             self._valid = os.path.isdir(directory) and name
         else:
-            self.valid = os.path.isdir(path)
+            self._valid = os.path.isdir(path)
         return self._valid
 
     def build(self):

--- a/zygrader/user.py
+++ b/zygrader/user.py
@@ -176,6 +176,23 @@ def save_password_toggle():
         window.run_layer(popup)
 
 
+def set_default_output_directory(row: ui.layers.Row):
+    window = ui.get_window()
+    directory = ui.layers.PathInputLayer("Default Output Directory",
+                                         directory=True)
+    directory.set_prompt(["Specify the default directory for output files."])
+    directory.set_text(preferences.get("output_dir"))
+    window.run_layer(directory)
+    if directory.was_canceled():
+        return
+
+    # Use get_text() instead of get_path() here so we can store ~
+    # in the preferences which is much shorter than the expanded version.
+    path = directory.get_text()
+    preferences.set("output_dir", path)
+    row.set_row_text(f"Default Output Directory: {path}")
+
+
 class PreferenceToggle(ui.layers.Toggle):
     def __init__(self, name, extra_fn=None):
         super().__init__()
@@ -237,6 +254,9 @@ def preferences_menu():
                        PreferenceToggle("clear_filter"))
     row.add_row_toggle("Open Diffs in Browser",
                        PreferenceToggle("browser_diff"))
+    output_row = row.add_row_text(
+        f"Default Output Directory: {preferences.get('output_dir')}")
+    output_row.set_callback_fn(set_default_output_directory, output_row)
 
     # Class code selector
     row = popup.add_row_parent("Class Code")

--- a/zygrader/user.py
+++ b/zygrader/user.py
@@ -1,5 +1,6 @@
 """User: User preference window management"""
 import base64
+import os
 
 from zygrader import data, ui, zybooks
 from zygrader.class_manager import download_roster
@@ -191,6 +192,10 @@ def set_default_output_directory(row: ui.layers.Row):
     path = directory.get_text()
     preferences.set("output_dir", path)
     row.set_row_text(f"Default Output Directory: {path}")
+
+    # Set the working directory to the new path for output and input files
+    # created by subprocesses (like student code)
+    os.chdir(directory.get_path())
 
 
 class PreferenceToggle(ui.layers.Toggle):


### PR DESCRIPTION
This adds a new preference for setting the default output directory for various operations within zygrader.
* Grade Puller
* Unmatched students
* Submission Search
* Student code i/o

For this to work, we set the zygrader current working directory to the path on startup, and whenever it is modified in the preferences.

Closes #33 