### PR TITLE
Fix #60: Grade puller reporting 0 for empty activities

### DIFF
--- a/zygrader/grade_puller.py
+++ b/zygrader/grade_puller.py
@@ -364,6 +364,10 @@ class GradePuller:
                 total_field_name = field_name
                 break
 
+        # Some sections are zero points but we still grade as if it were 100.
+        # In these cases, always give the student 100%.
+        is_empty_activity = "0" in total_field_name
+
         bad_id_count = 0
         report = dict()
         for row in csv_reader:
@@ -383,7 +387,8 @@ class GradePuller:
             while real_id in report:
                 real_id = str(real_id) + "(02)"
             row["id_number"] = real_id
-            row["grade"] = float(row[total_field_name])
+            row["grade"] = float(
+                row[total_field_name]) if not is_empty_activity else 100
             report[real_id] = row
 
         return report, header

--- a/zygrader/grade_puller.py
+++ b/zygrader/grade_puller.py
@@ -366,7 +366,7 @@ class GradePuller:
 
         # Some sections are zero points but we still grade as if it were 100.
         # In these cases, always give the student 100%.
-        is_empty_activity = "0" in total_field_name
+        is_empty_activity = "(0)" in total_field_name
 
         bad_id_count = 0
         report = dict()


### PR DESCRIPTION
Activities that have no lab, challenge, or preparation activity should be counted as a 100%, not a zero.

Not sure if this is a proper solution since I am not super familiar with the code. But in the case of 7.19-7.20 it reported 100s!
And I tested 7.16-7.18 which seemed to report the proper scores as well. 

Closes #60 