### PR TITLE
Fix #77: No indication for empty parent rows

### DIFF
--- a/zygrader/ui/layers.py
+++ b/zygrader/ui/layers.py
@@ -453,6 +453,10 @@ class Row:
         self.__radio: RadioGroup = None
         self.__radio_id = ""
 
+        # Disable parent rows until children are added
+        if _type == Row.PARENT:
+            self.__disabled = True
+
     def __str__(self):
         """Render a textual representation of this row."""
         if self.__type == Row.TEXT:
@@ -479,6 +483,11 @@ class Row:
     def __add_row(self, text: str, _type=TEXT):
         row = Row(text, _type)
         self.__subrows.append(row)
+
+        # Enable parent rows when adding children
+        if self.__type == Row.PARENT and self.__disabled:
+            self.__disabled = False
+
         return row
 
     def add_row_text(self, text: str, callback_fn=None, *args):


### PR DESCRIPTION
This is a simple fix. Parent rows are set to disabled by default, and adding children enables them again.

---

For testing

```python3
diff --git a/zygrader/user.py b/zygrader/user.py
index a45d644..a032874 100644
--- a/zygrader/user.py
+++ b/zygrader/user.py
@@ -240,6 +240,9 @@ def preferences_menu():
     popup = ui.layers.ListLayer("User Preferences", popup=True)
     popup.set_exit_text("Close")
 
+    # TEST
+    row = popup.add_row_parent("TEST")
+
     # Appearance sub-menu
     row = popup.add_row_parent("Appearance")
     row.add_row_toggle("Dark Mode", PreferenceToggle("dark_mode"))
```

or just look at the optional chapter separators in the grade puller