### PR TITLE
Fix #78: View submissions from email manager

### DIFF
--- a/zygrader/email_manager.py
+++ b/zygrader/email_manager.py
@@ -3,10 +3,15 @@
 import curses
 import getpass
 
-from zygrader import data, ui
+from zygrader import data, grader, ui
 
 
-def lock_student_callback(student):
+def view_email_submissions(student: data.Student):
+    """View submissions from the locked student"""
+    grader.grade(use_locks=False, student=student)
+
+
+def lock_student_callback(student: data.Student):
     window = ui.get_window()
 
     if data.lock.is_locked(student):
@@ -20,7 +25,8 @@ def lock_student_callback(student):
     try:
         data.lock.lock(student)
         msg = [f"You have locked {student.full_name} for emailing."]
-        popup = ui.layers.Popup("Student Locked", msg)
+        popup = ui.layers.OptionsPopup("Student Locked", msg)
+        popup.add_option("View Submitted Code", lambda: view_email_submissions(student))
         window.run_layer(popup)
     finally:
         data.lock.unlock(student)

--- a/zygrader/grader.py
+++ b/zygrader/grader.py
@@ -394,11 +394,16 @@ def watch_students(student_list, students, lab, use_locks):
                                     lab, use_locks, student_select_fn)
 
 
-def lab_select_fn(selected_index, use_locks):
+def lab_select_fn(selected_index, use_locks, student: model.Student=None):
     """Create the list of labs to pick a student to grade"""
     window = ui.get_window()
     lab = data.get_labs()[selected_index]
     students = data.get_students()
+
+    # A student is already selected, open the grader
+    if student:
+        student_select_fn(student, lab, use_locks)
+        return
 
     student_list = ui.layers.ListLayer()
     student_list.set_searchable("Student")
@@ -414,7 +419,7 @@ def lab_select_fn(selected_index, use_locks):
     window.register_layer(student_list, lab.name)
 
 
-def grade(use_locks=True):
+def grade(use_locks=True, student: model.Student=None):
     """Create the list of labs to pick one to grade"""
     window = ui.get_window()
     labs = data.get_labs()
@@ -432,5 +437,5 @@ def grade(use_locks=True):
     lab_list = ui.layers.ListLayer()
     lab_list.set_searchable("Lab")
     for index, lab in enumerate(labs):
-        lab_list.add_row_text(str(lab), lab_select_fn, index, use_locks)
+        lab_list.add_row_text(str(lab), lab_select_fn, index, use_locks, student)
     window.register_layer(lab_list, title)


### PR DESCRIPTION
Add an option to the email manager to view student submissions. This requires
a small modification to the grader to optionally pass in a student. The usual
grader flow goes Lab -> Student -> Submission, but we need to skip the Student
step in this process.

So the lab list function now has an optional parameter for a student. If that
student is defined, then the Student list step is skipped and the submission is
immediately shown.

Additionally, the use_locks argument is False to prevent locking in the case
of just viewing code.

Closes #78 