### PR TITLE
Window: Add debug console

### DIFF
--- a/zygrader/main.py
+++ b/zygrader/main.py
@@ -54,6 +54,10 @@ def parse_args():
                         "--admin",
                         action="store_true",
                         help="Enable admin features")
+    parser.add_argument("-d",
+                        "--debug",
+                        action="store_true",
+                        help="Show the debug console")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-n",
                        "--no-update",

--- a/zygrader/ui/window.py
+++ b/zygrader/ui/window.py
@@ -46,7 +46,7 @@ class Window:
         self.name = window_name
 
         # Debug console data
-        self.__debug_mode = True
+        self.__debug_mode = args.debug
         self.__debug_lines = []
         self.__debug_win = None
 

--- a/zygrader/ui/window.py
+++ b/zygrader/ui/window.py
@@ -291,7 +291,7 @@ class Window:
         self.__debug_win.hline(0, 0, "_", self.cols)
 
         row_num = 1
-        display_rows = self.__debug_lines[-4:]
+        display_rows = self.__debug_lines[-DEBUG_CONSOLE_HEIGHT:]
         for row in display_rows:
             add_str(self.__debug_win, row_num, 0, row)
             row_num += 1


### PR DESCRIPTION
Adds a debugging console to the window manager. This can be enabled with the `-d` or `--debug` flags to zygrader.

At the moment the height is set to 4 rows and will scroll to show the last 4 rows of output. At this point it is useful enough to include in zygrader, but more could be added in the future.