### PR TITLE
Netid to name

### DIFF
--- a/zygrader/admin.py
+++ b/zygrader/admin.py
@@ -185,8 +185,7 @@ def remove_locks():
     window.run_layer(popup)
 
     selected_locks = [lock for lock in all_locks if all_locks[lock]]
-
-    if not selected_locks or popup.canceled:
+    if not selected_locks:
         return
 
     # Confirm

--- a/zygrader/data/__init__.py
+++ b/zygrader/data/__init__.py
@@ -1,5 +1,6 @@
 import json
 import os
+import typing
 
 from zygrader.config.shared import SharedData
 
@@ -139,7 +140,7 @@ def load_tas() -> list:
     return SharedData.TAS
 
 
-def get_tas() -> list:
+def get_tas() -> typing.List[TA]:
     if SharedData.TAS:
         return SharedData.TAS
 
@@ -157,3 +158,15 @@ def write_tas(tas):
     path = SharedData.get_ta_data()
     with open(path, "w") as _file:
         json.dump(tas_json, _file, indent=2)
+
+
+def netid_to_name(netid: str) -> str:
+    """
+    Return the full name of the TA from the netid.
+    If it doesn't exit in the database then return only the netid.
+    """
+    tas = get_tas()
+    for ta in tas:
+        if ta.netid == netid:
+            return ta.queue_name
+    return netid

--- a/zygrader/email_manager.py
+++ b/zygrader/email_manager.py
@@ -17,7 +17,8 @@ def lock_student_callback(student: data.Student):
     if data.lock.is_locked(student):
         netid = data.lock.get_locked_netid(student)
         if netid != getpass.getuser():
-            msg = [f"{netid} is replying to {student.first_name}'s email"]
+            name = data.netid_to_name(netid)
+            msg = [f"{name} is replying to {student.first_name}'s email"]
             popup = ui.layers.Popup("Student Locked", msg)
             window.run_layer(popup)
             return
@@ -26,7 +27,8 @@ def lock_student_callback(student: data.Student):
         data.lock.lock(student)
         msg = [f"You have locked {student.full_name} for emailing."]
         popup = ui.layers.OptionsPopup("Student Locked", msg)
-        popup.add_option("View Submitted Code", lambda: view_email_submissions(student))
+        popup.add_option("View Submitted Code",
+                         lambda: view_email_submissions(student))
         window.run_layer(popup)
     finally:
         data.lock.unlock(student)

--- a/zygrader/grader.py
+++ b/zygrader/grader.py
@@ -232,7 +232,8 @@ def can_get_through_locks(use_locks, student, lab):
 
         # If being graded by the user who locked it, allow grading
         if netid != getpass.getuser():
-            msg = [f"This student is already being graded by {netid}"]
+            name = data.netid_to_name(netid)
+            msg = [f"This student is already being graded by {name}"]
             popup = ui.layers.Popup("Student Locked", msg)
             window.run_layer(popup)
             return False


### PR DESCRIPTION
Show netid as TA full name if it exists in the database
    
Now that Bob's Shake stores a relation between the netid and name of all
the TAs we can display the name rather than netid in the grader and email
lock messages.
    
If there is no name it falls back to netid.