### PR TITLE
Store refresh token instead of auth token

### DIFF
--- a/zygrader/config/preferences.py
+++ b/zygrader/config/preferences.py
@@ -21,7 +21,7 @@ EDITORS = {
 # Also used for determining if a key is valid for set() and get().
 DEFAULT_PREFERENCES = {
     "version": SharedData.VERSION.vstring,
-    "token": "",
+    "refresh_token": "",
     "left_right_arrow_nav": True,
     "use_esc_back": False,
     "clear_filter": True,

--- a/zygrader/config/versioning.py
+++ b/zygrader/config/versioning.py
@@ -120,7 +120,9 @@ def versioning_update_preferences():
 
     ##### Versioning code to run until next version bump ######
     if True:
-        pass
+        # We no longer store the auth token, instead store the refresh token.
+        # Using this as an opportunity to use better naming.
+        preferences.remove("token")
     #### Leave this `if True` block after bumping version! ####
 
 

--- a/zygrader/main.py
+++ b/zygrader/main.py
@@ -167,7 +167,7 @@ def main(window: ui.Window, args):
 
     # Authenticate the user
     zybooks_api = zybooks.Zybooks()
-    if not preferences.get("token") or not user.authenticate(
+    if not preferences.get("refresh_token") or not user.authenticate(
             window, zybooks_api):
         user.login(window)
 


### PR DESCRIPTION
When signing in to zyBooks an auth token and a refresh token are returned.
Previously we only stored the auth token, but it turns out this expires after
about two days from creation. After expiration the refresh token is used
to generate a new auth token.

Now we store the refresh token in the preferences. On startup we send the
refresh token to zybooks which sends us back a new auth token to use for the
session.

A better solution might be to store the expiry date as well, and then only
send a request when the auth has expired. This can be done in a follow0up
commit if needed.