### PR TITLE
Cleanup tempfiles when closing zygrader

### DIFF
--- a/zygrader/data/model.py
+++ b/zygrader/data/model.py
@@ -4,7 +4,6 @@ import enum
 import os
 import signal
 import subprocess
-import tempfile
 import time
 from collections import Iterable
 
@@ -287,7 +286,7 @@ class Submission(Iterable):
 
     def read_files(self, response):
         zy_api = Zybooks()
-        tmp_dir = tempfile.mkdtemp()
+        tmp_dir = utils.create_tempdir()
 
         # Look through each part
         for part in response["parts"]:
@@ -422,7 +421,7 @@ class Submission(Iterable):
 
     def compile_code(self):
         # Use a separate tmp dir to avoid opening the binary in a text editor
-        tmp_dir = tempfile.mkdtemp()
+        tmp_dir = utils.create_tempdir()
         executable_name = os.path.join(tmp_dir, "run")
 
         root_dir = self.files_directory


### PR DESCRIPTION
Adds a wrapper around tempfile.TemporaryDirectory and replaces
each existing call to mkdtemp with the wrapper function. This function
stores the temporary directories in a list. When zygrader is exited
this list is destroyed, and each directory in the list is automatically
deleted.

These paths are also prefixed with "zy" to distinguish from other tmp
directories.

I tested and the files are removed both when closing normally and when
killing zygrader.